### PR TITLE
Add webfinger file to .well-known

### DIFF
--- a/.well-known/webfinger
+++ b/.well-known/webfinger
@@ -1,0 +1,23 @@
+{
+	"subject": "acct:hisaac@mspsocial.net",
+	"aliases": [
+		"https://mspsocial.net/@hisaac",
+		"https://mspsocial.net/users/hisaac"
+	],
+	"links": [
+		{
+			"rel": "http://webfinger.net/rel/profile-page",
+			"type": "text/html",
+			"href": "https://mspsocial.net/@hisaac"
+		},
+		{
+			"rel": "self",
+			"type": "application/activity+json",
+			"href": "https://mspsocial.net/users/hisaac"
+		},
+		{
+			"rel": "http://ostatus.org/schema/1.0/subscribe",
+			"template": "https://mspsocial.net/authorize_interaction?uri={uri}"
+		}
+	]
+}


### PR DESCRIPTION
This adds hisaac.net discoverability for Mastodon/fediverse