### PR TITLE
[Blog Post] How to Speed Up Codecov Analysis for Xcode Projects, Revisited

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-hugo = "extended_0.128.0"
-node = "22.3.0"
+hugo = "extended_0.133.1"
+node = "22.7.0"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
 		"Cudi",
 		"Evernote",
 		"Kanye",
+		"lcov",
 		"letsencrypt",
 		"protip",
 		"Purrp",
@@ -13,6 +14,7 @@
 		"Thinkin",
 		"unirest",
 		"Wassup",
-		"webdev"
+		"webdev",
+		"xcresultparser"
 	]
 }

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -27,7 +27,7 @@ body {
 	background-color: var(--color-background);
 	color: var(--color-text);
 	margin: auto;
-	max-width: 1000px;
+	max-width: 75ch;
 	padding: 1em;
 	tab-size: 4;
 }
@@ -50,6 +50,7 @@ aside {
 	background-color: var(--color-accented-background);
 	padding: 1em;
 	border-radius: 4px;
+	margin-bottom: 1em;
 }
 
 aside p {

--- a/src/content/blog/2023/how-to-speed-up-codecov-analysis-for-xcode-projects/index.md
+++ b/src/content/blog/2023/how-to-speed-up-codecov-analysis-for-xcode-projects/index.md
@@ -5,6 +5,12 @@ tags: [software, programming, swift, apple]
 ---
 
 <aside>
+<strong>💁🏻‍♂️ Update:</strong> Since writing this post, I've found a new method for converting Xcode's code coverage format to a format that Codecov can ingest. This method is slightly faster and — more importantly — removes the dependency on external tools, instead relying solely on tools included within Xcode's command line tools.
+
+Check out my [new post]({{< ref "how-to-speed-up-codecov-analysis-for-xcode-projects-revisited" >}}) for more details.
+</aside>
+
+<aside>
 <strong>💁🏻‍♂️ Note:</strong> A version of this post also appeared on the <a href="https://about.codecov.io/blog/pre-converting-xcresult-files-for-codecov-using-xcresultparser/">Codecov Blog</a> and <a href="https://thenewstack.io/speeding-up-codecov-analysis-for-xcode-projects/">The New Stack</a>.
 </aside>
 

--- a/src/content/blog/2024/how-to-speed-up-codecov-analysis-for-xcode-projects-revisited/index.md
+++ b/src/content/blog/2024/how-to-speed-up-codecov-analysis-for-xcode-projects-revisited/index.md
@@ -1,0 +1,109 @@
+---
+title: "How to Speed Up Codecov Analysis for Xcode Projects, Revisited"
+date: 2024-09-01
+tags: [xcode, software, programming, swift, apple]
+---
+
+In a [previous post]({{< ref "how-to-speed-up-codecov-analysis-for-xcode-projects" >}}), I outlined a method for converting Xcode's code coverage format to a format that [Codecov](https://codecov.io) can ingest. This method relied on an open source tool called [`xcresultparser`](https://github.com/a7ex/xcresultparser).
+
+Since writing that post, I've found a new method that is slightly faster and — more importantly — removes the dependency on external tools, instead relying solely on tools included within Xcode's command line tools.
+
+Codecov lists the code coverage formats it natively accepts in its documentation here: [Supported Coverage Report Formats](https://docs.codecov.com/docs/supported-report-formats). Among the accepted formats is `lcov`.
+
+Xcode includes a tool called `llvm-cov`, which can be called from the command line using `xcrun`:
+
+```shell
+xcrun llvm-cov
+```
+
+`llvm-cov`'s has a number of subcommands, but the one we're interested in is `export`. This command does the conversion we need from Xcode's native format to the more interoperable `lcov` format.
+
+## 1. Run the Tests
+
+In order to use the `export` command, we'll need to gather a couple dependencies that need to be passed to it in order to do the conversion.
+
+First, we need to know the location of the DerivedData directory. In order to isolate your test results to just the tests that you care about, I recommend using the `-derivedDataPath` flag to specify the location of DerivedData explicitly in whatever `xcodebuild` command you use to run your tests. (I usually just put it at the present working directory for easy future reference.)
+
+```shell
+xcrun xcodebuild test -derivedDataPath ./DerivedData ...
+```
+
+## 2. Gather Information
+
+Next, we need to locate the Profile data generated during testing. This will be a file named `Coverage.profdata`, and will be located in a subdirectory of `DerivedData/Build/ProfileData`. You can use a `find` command to locate it like so:
+
+```bash
+find "./DerivedData/Build/ProfileData" -name "Coverage.profdata"
+
+# example result:
+# ./DerivedData/Build/ProfileData/00006000-000420CA0CA3801E/Coverage.profdata
+```
+
+Finally, we need to get a list of all the test bundles generated when running our tests. These will be files with a `.xctest` extension, and will be located in various locations within `./DerivedData/Build/Products`. We can use a `find` command to locate them like so:
+
+```bash
+find "./DerivedData/Build/Products" -name "*.xctest"
+
+# example result:
+# ./DerivedData/Build/Products/Debug-iphoneos/MyAppUITests-Runner.app/PlugIns/MyAppUITests.xctest
+# ./DerivedData/Build/Products/Debug-iphoneos/MyApp.app/PlugIns/MyAppTests.xctest
+# ./DerivedData/Build/Products/Debug-iphoneos/.XCInstall/MyApp.app/Wrapper/MyApp.app/PlugIns/MyAppTests.xctest
+```
+
+What `llvm-cov` expects is the path to the binary within these test bundles. They will be located at the root of each bundle, and be named the same as the bundle itself. You can use the `basename` function in bash to get the name like so:
+
+```bash
+basename "./DerivedData/Build/Products/Debug-iphoneos/MyAppUITests-Runner.app/PlugIns/MyAppUITests.xctest" .xctest
+
+# example result:
+# MyAppUITests
+```
+
+## 3. Convert!
+
+Now that we've located that information, we can pass it to the `llvm-cov export` command. The command will need to be run separately for each test bundle you're handling, so we'll run it multiple times within a loop.
+
+Here's a simple bash script that puts all the pieces together:
+
+```bash
+#!/bin/bash
+
+set -o errexit  # Exit on error
+set -o nounset  # Exit on unset variable
+set -o pipefail # Exit on pipe failure
+
+function main() {
+	declare -r coverage_profdata_path="$(
+		find "./DerivedData/Build/ProfileData" -name "Coverage.profdata"
+	)"
+
+	declare -r xctest_bundles="$(
+		find "./DerivedData/Build/Products" -name "*.xctest"
+	)"
+
+	# Loop through each test bundle and convert the coverage data to lcov format
+	while IFS= read -r test_bundle; do
+
+		# Get the test bundle name
+		test_bundle_name="$(basename "$test_bundle" .xctest)"
+
+		# Get the test bundle binary path
+		test_bundle_binary_path="${test_bundle}/${test_bundle_name}"
+
+		# Define where the converted coverage data will be output
+		output_path="./artifacts/${test_bundle_name}.coverage.info"
+
+		# Convert the coverage data to lcov format
+		xcrun llvm-cov export --format lcov \
+			--instr-profile "${coverage_profdata_path}" \
+			"${test_bundle_binary_path}" >"${output_path}"
+
+	done <<<"${xctest_bundles}"
+}
+
+main "$@"
+```
+
+This script will produce a number of text files with the extension `.coverage.info` within a directory named `artifacts`. From there, you can upload these text files to Codecov and let it work its magic!
+
+As I said before, this does run slightly faster than the `xcresultparser` method, but the biggest win is the fact that it removes a dependency on a tool, which is always welcome.

--- a/src/content/projects/index.md
+++ b/src/content/projects/index.md
@@ -8,11 +8,14 @@ menu: main
 [CenterMouse](/projects/CenterMouse)
 :	A macOS utility that moves your mouse pointer to the center of the screen on certain events.
 
+[`xcb`](https://github.com/hisaac/xcb) (in early development)
+:	A Swift CLI for interacting with the `xcodebuild` and `swift` CLI tools, providing nicer defaults, new features, and improved ergonomics.
+
 [Sensorium](https://github.com/hisaac/Sensorium/) (in development)
 :	A macOS utility that can perform actions based on events.
 :	(Heavily inspired by the now-defunct [ControlPlane](https://github.com/dustinrue/ControlPlane).)
 
-[PlainPasta](https://github.com/hisaac/PlainPasta)
+[PlainPasta](https://github.com/hisaac/PlainPasta) (retired)
 :	A macOS utility that removes any styling from text on the clipboard.
 
 [Tiime](https://github.com/hisaac/Tiime) (retired)


### PR DESCRIPTION
## What's changed?

The main goal of this PR is to add a new blog post, titled "How to Speed Up Codecov Analysis for Xcode Projects Revisited".

It also includes a few unrelated but nice updates:

- Updates `hugo` to version 1.33.0 extended
- Updates `node` to version 22.7.0
- Adds a few items to VSCode's spell checking whitelist
- Makes maximum page width 75 characters for better readability